### PR TITLE
Fix printed results

### DIFF
--- a/Code/EntryPoint.cpp
+++ b/Code/EntryPoint.cpp
@@ -153,5 +153,8 @@ int main(int argc, const char * argv[]) {
 	}
 
 
+	overlapped_io_file_read->PrintResults();
+
+
 	return 0;
 }

--- a/Code/OverlappedIOFileRead.cpp
+++ b/Code/OverlappedIOFileRead.cpp
@@ -168,7 +168,10 @@ namespace FileReadSpeedTest {
 		// Wait for worker threads to finish
 		WaitForMultipleObjects(static_cast<DWORD>(thread_pool_.threads_.size()), (const HANDLE*)thread_pool_.threads_.data(), TRUE, INFINITE);
 		*/
+		PrintResults();
+	}
 
+	void OverlappedIOFileRead::PrintResults() noexcept {
 		auto open_delay = std::chrono::duration_cast<std::chrono::nanoseconds>(overlapped_io_file_.file_open_time_ - pre_open_time_);
 		auto open_to_read_delay = std::chrono::duration_cast<std::chrono::nanoseconds>(read_issue_time_ - overlapped_io_file_.file_open_time_);
 		std::cout << "Open delay: " << open_delay << std::endl;

--- a/Code/OverlappedIOFileRead.hpp
+++ b/Code/OverlappedIOFileRead.hpp
@@ -64,6 +64,8 @@ namespace FileReadSpeedTest {
 		void Read() noexcept;
 		void WaitForThreadsToFinish() noexcept;
 
+		void PrintResults() noexcept;
+
 		OverlappedIOFile overlapped_io_file_;
 		CompletionPort completion_port_;
 		// TODO: Put contexts in their own cache line so there isn't cache contention

--- a/Code/OverlappedIOFileReadTask.cpp
+++ b/Code/OverlappedIOFileReadTask.cpp
@@ -41,7 +41,8 @@ namespace FileReadSpeedTest {
 
 		BOOL result = GetQueuedCompletionStatus(overlapped_io_file_read_->completion_port_.handle_, &bytes_transferred, &completion_key, reinterpret_cast<LPOVERLAPPED*>(&context), INFINITE);
 
-		std::cout << "Buffer received" << std::endl;
+		context->request_complete_time_ = std::chrono::high_resolution_clock::now();
+		context->is_complete_ = true;
 
 		auto new_read_offset = GetNewReadOffset(overlapped_io_file_read_->file_size_, /* TODO: use context->file_offset_ */ current_read_start_, buffer_interval_in_bytes_);
 		if (!new_read_offset.has_value()) {


### PR DESCRIPTION
The printed results were broken a while ago. I believe this happened during the move to using max's thread pool just to make the transition easier.

This commit brings back the printed results.

This closes #26