### PR TITLE
Add --queue_depth parameter

### DIFF
--- a/Code/CommandLineParameters.cpp
+++ b/Code/CommandLineParameters.cpp
@@ -20,6 +20,7 @@ namespace FileReadSpeedTest {
 		ErrorNode = 3,
 		AwaitingBufferSizeNode = 4,
 		AwaitingThreadCountNode = 5,
+		AwaitingQueueDepthNode = 6,
 	};
 
 	Action ProcessCommandLineParameters(int argc, const char * argv[]) noexcept {
@@ -47,6 +48,11 @@ namespace FileReadSpeedTest {
 			max::Containers::StateMachine::Transition{
 				max::Containers::StateMachine::StringMatcher{std::string_view{"--thread_count"}}, [](const std::string_view& input) {
 					return NodeIndices::AwaitingThreadCountNode;
+				}
+			},
+			max::Containers::StateMachine::Transition{
+				max::Containers::StateMachine::StringMatcher{std::string_view{"--queue_depth"}}, [](const std::string_view& input) {
+					return NodeIndices::AwaitingQueueDepthNode;
 				}
 			},
 			max::Containers::StateMachine::Transition{
@@ -112,7 +118,25 @@ namespace FileReadSpeedTest {
 			}
 		);
 
-		auto state_machine = max::Containers::StateMachine::StateMachine{NodeIndices::StartNode, std::make_tuple(start_node, awaiting_flags_node, std::move(awaiting_input_file_node), std::move(error_node), awaiting_buffer_size_node, awaiting_thread_count_node)};
+		auto queue_depth = std::optional<size_t>{std::nullopt};
+		auto awaiting_queue_depth_node = max::Containers::StateMachine::MakeNode(NodeIndices::AwaitingQueueDepthNode,
+			max::Containers::StateMachine::Transition{
+				max::Containers::StateMachine::AnythingMatcher<std::string_view>{}, [&queue_depth, &error_message](const std::string_view& input) {
+					// TODO: Also here
+					char * end = nullptr;
+					unsigned long long temp = std::strtoull(input.data(), &end, /*base=*/10);
+					if (errno == ERANGE) {
+						error_message = "Could not convert parameter to number: ";
+						*error_message += input;
+						return NodeIndices::ErrorNode;
+					}
+					queue_depth = temp;
+					return NodeIndices::AwaitingFlagsNode;
+				}
+			}
+		);
+
+		auto state_machine = max::Containers::StateMachine::StateMachine{NodeIndices::StartNode, std::make_tuple(start_node, awaiting_flags_node, std::move(awaiting_input_file_node), std::move(error_node), awaiting_buffer_size_node, awaiting_thread_count_node, awaiting_queue_depth_node)};
 
 
 
@@ -133,7 +157,7 @@ namespace FileReadSpeedTest {
 
 
 
-		return Action{SuccessAction{std::move(*input_file), std::move(buffer_size), std::move(thread_count)}};
+		return Action{SuccessAction{std::move(*input_file), std::move(buffer_size), std::move(thread_count), std::move(queue_depth)}};
 	}
 
 } // namespace FileReadSpeedTest

--- a/Code/CommandLineParameters.hpp
+++ b/Code/CommandLineParameters.hpp
@@ -16,6 +16,7 @@ namespace FileReadSpeedTest {
 		std::string_view file_path_;
 		std::optional<size_t> buffer_size_;
 		std::optional<size_t> thread_count_;
+		std::optional<size_t> queue_depth_;
 	};
 
 	struct ErrorAction {

--- a/Code/EntryPoint.cpp
+++ b/Code/EntryPoint.cpp
@@ -68,6 +68,9 @@ int main(int argc, const char * argv[]) {
 
 
 
+
+
+
 	// Open the file.
 	auto file = FileReadSpeedTest::CreateOverlappedIOFile(input_file.data());
 	if (!file.has_value()) {
@@ -98,12 +101,28 @@ int main(int argc, const char * argv[]) {
 
 
 
+	// Get queue depth
+	auto queue_depth = size_t{0};
+	auto command_line_queue_depth = std::get<FileReadSpeedTest::SuccessAction>(action).queue_depth_;
+	if (command_line_queue_depth.has_value()) {
+		queue_depth = *command_line_queue_depth;
+		std::cout << "Using supplied queue_depth: " << queue_depth << std::endl;
+	} else {
+		// TODO: There is probably an ideal queue depth.
+		// Research this.
+		queue_depth = thread_pool->task_threads_.size();
+		std::cout << "Using queue depth = thread count: " << queue_depth << std::endl;
+	}
+
+
+
 	// Prepare to read the file.
 	auto overlapped_io_file_read = FileReadSpeedTest::PrepareToReadFile(*file, worker_thread_count, buffer_size);
 	if (!overlapped_io_file_read.has_value()) {
 		std::cerr << "Error reading file\n";
 		return -1;
 	}
+
 
 
 	// Create main task queue to receive completion notifications
@@ -115,16 +134,13 @@ int main(int argc, const char * argv[]) {
 	size_t completed_threads = 0;
 	
 
-	// Issue initial reads.
-	overlapped_io_file_read->Read();
-
 
 	// Add initial read tasks to the thread pool
 	size_t thread_count = thread_pool->task_threads_.size();
 	LARGE_INTEGER current_read_start = {};
-	size_t i = 0;
-	for (auto& thread: thread_pool->task_threads_) {
-		auto add_task_result = thread.task_queue_->AddTask(std::make_unique<FileReadSpeedTest::OverlappedIOFileReadTask>(&overlapped_io_file_read.value(), current_read_start, thread_count * buffer_size, i, thread_count, thread.task_queue_.get(), main_task_queue->get(), &completed_threads));
+	auto i = size_t{0};
+	for (auto& thread : thread_pool->task_threads_) {
+		auto add_task_result = thread.task_queue_->AddTask(std::make_unique<FileReadSpeedTest::OverlappedIOFileReadTask>(&overlapped_io_file_read.value(), current_read_start, queue_depth * buffer_size, i, thread_count, queue_depth, thread.task_queue_.get(), main_task_queue->get(), &completed_threads));
 		switch (add_task_result) {
 		case max::Hardware::CPU::TaskQueue::AddTaskError::Okay:
 			break;
@@ -138,12 +154,22 @@ int main(int argc, const char * argv[]) {
 	}
 
 
+
+	// Issue initial reads.
+	overlapped_io_file_read->read_issue_time_ = std::chrono::high_resolution_clock::now();
+	for (size_t i = 0; i < queue_depth; i++) {
+		overlapped_io_file_read->Read(i);
+	}
+
+
+
 	// Wait for all tasks to be complete.
 	// TODO: Currently, the Shutdown is queued up before the follow-up tasks.
 	max::Hardware::CPU::TaskRunnerLoop(main_task_queue->get());
 
 
 
+	// TODO: If queue depth is less than thread pool size, some threads will always be waiting.
 	// Shutdown thread pool. Wait for the shutdown to complete.
 	for (auto& thread: thread_pool->task_threads_) {
 		thread.task_queue_->Shutdown();
@@ -153,6 +179,10 @@ int main(int argc, const char * argv[]) {
 	}
 
 
+
+	// TODO: There seems to be some sort of race condition when queue depth != thread count.
+	// Some of the times aren't updated away from 0.
+	// This might also be context[i]->time is set on the wrong i.
 	overlapped_io_file_read->PrintResults();
 
 

--- a/Code/OverlappedIOFileRead.cpp
+++ b/Code/OverlappedIOFileRead.cpp
@@ -121,26 +121,20 @@ namespace FileReadSpeedTest {
 		, file_size_(std::move(file_size))
 	{}
 
-	void OverlappedIOFileRead::Read() noexcept {
-		read_issue_time_ = std::chrono::high_resolution_clock::now();
-
-		// TODO: Only have a certain number of IOPS in flight at a time?
-		for (DWORD i = 0; i < contexts_.size(); ++i) {
-			contexts_[i].request_start_time_ = std::chrono::high_resolution_clock::now();
-			BOOL result = ReadFile(overlapped_io_file_.handle_, contexts_[i].buffer_.memory_, contexts_[i].bytes_to_read_, nullptr, &contexts_[i].overlapped_);
-			if (!result) {
-				DWORD error = GetLastError();
-				// TODO: ERROR_INVALID_USER_BUFFER or ERROR_NOT_ENOUGH_MEMORY if too many outstanding asynchronous IO operations
-				if (error != ERROR_IO_PENDING) {
-					// TODO: error
-					continue;
-				}
+	void OverlappedIOFileRead::Read(size_t context_index) noexcept {
+		contexts_[context_index].request_start_time_ = std::chrono::high_resolution_clock::now();
+		BOOL result = ReadFile(overlapped_io_file_.handle_, contexts_[context_index].buffer_.memory_, contexts_[context_index].bytes_to_read_, nullptr, &contexts_[context_index].overlapped_);
+		if (!result) {
+			DWORD error = GetLastError();
+			// TODO: ERROR_INVALID_USER_BUFFER or ERROR_NOT_ENOUGH_MEMORY if too many outstanding asynchronous IO operations
+			if (error != ERROR_IO_PENDING) {
+				// TODO: error
 			}
-
-			// TODO: Handle when the OS makes the operation synchronous:
-			// https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/asynchronous-disk-io-synchronous
-			// This can happen when FS compression or encryption is enabled.
 		}
+
+		// TODO: Handle when the OS makes the operation synchronous:
+		// https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/asynchronous-disk-io-synchronous
+		// This can happen when FS compression or encryption is enabled.
 	}
 
 	void OverlappedIOFileRead::WaitForThreadsToFinish() noexcept {

--- a/Code/OverlappedIOFileRead.hpp
+++ b/Code/OverlappedIOFileRead.hpp
@@ -61,7 +61,7 @@ namespace FileReadSpeedTest {
 
 		explicit OverlappedIOFileRead(OverlappedIOFile overlapped_io_file, CompletionPort completion_port, std::vector<IOContext> contexts, LARGE_INTEGER file_size) noexcept;
 
-		void Read() noexcept;
+		void Read(size_t context_index) noexcept;
 		void WaitForThreadsToFinish() noexcept;
 
 		void PrintResults() noexcept;
@@ -72,7 +72,7 @@ namespace FileReadSpeedTest {
 		std::vector<IOContext> contexts_;
 		LARGE_INTEGER file_size_;
 		std::chrono::time_point<std::chrono::high_resolution_clock> read_issue_time_;
-	
+
 	};
 
 	std::optional<size_t> GetIdealBufferSize(const OverlappedIOFile& file) noexcept;

--- a/Code/OverlappedIOFileReadTask.cpp
+++ b/Code/OverlappedIOFileReadTask.cpp
@@ -11,24 +11,13 @@
 
 namespace FileReadSpeedTest {
 
-	/*
-	OverlappedIOFileReadTask::OverlappedIOFileReadTask(HANDLE completion_port, size_t buffer_interval_in_bytes, LARGE_INTEGER file_size) noexcept
-		: completion_port_(std::move(completion_port))
-		, buffer_interval_in_bytes_(std::move(buffer_interval_in_bytes))
-		, file_size_(std::move(file_size))
-	{}
-	*/
-	/*
-	OverlappedIOFileReadTask::OverlappedIOFileReadTask(OverlappedIOFileRead* overlapped_io_file_read) noexcept
-		: overlapped_io_file_read_(std::move(overlapped_io_file_read))
-	{}
-	*/
-	OverlappedIOFileReadTask::OverlappedIOFileReadTask(OverlappedIOFileRead* overlapped_io_file_read, LARGE_INTEGER current_read_start, size_t buffer_interval_in_bytes, size_t context_index, size_t thread_count, max::Hardware::CPU::TaskQueue* task_queue, max::Hardware::CPU::TaskQueue* main_task_queue, size_t* completed_threads) noexcept
+	OverlappedIOFileReadTask::OverlappedIOFileReadTask(OverlappedIOFileRead* overlapped_io_file_read, LARGE_INTEGER current_read_start, size_t buffer_interval_in_bytes, size_t context_index, size_t thread_count, size_t queue_depth, max::Hardware::CPU::TaskQueue* task_queue, max::Hardware::CPU::TaskQueue* main_task_queue, size_t* completed_threads) noexcept
 		: overlapped_io_file_read_(std::move(overlapped_io_file_read))
 		, current_read_start_(std::move(current_read_start))
 		, buffer_interval_in_bytes_(std::move(buffer_interval_in_bytes))
 		, context_index_(std::move(context_index))
 		, thread_count_(std::move(thread_count))
+		, queue_depth_(std::move(queue_depth))
 		, task_queue_(std::move(task_queue))
 		, main_task_queue_(std::move(main_task_queue))
 		, completed_threads_(std::move(completed_threads))
@@ -63,11 +52,15 @@ namespace FileReadSpeedTest {
 
 
 
+		// TODO: If buffers arrive out of order, we might issue reads out of order as well.
+		// But to fix that, we might need to synchronize on the next buffer read to issue?
+		// If we synchronize, that'll be a performance hit.
+		size_t new_context_index = context_index_ + queue_depth_;
+		// Because we have more file left & took one of the reads off the queue, put another one on.
+		overlapped_io_file_read_->Read(new_context_index);
 
-		size_t new_context_index = context_index_ + thread_count_;
 
-
-		auto add_task_result = task_queue_->AddTask(std::make_unique<OverlappedIOFileReadTask>(overlapped_io_file_read_, *new_read_offset, buffer_interval_in_bytes_, new_context_index, thread_count_, task_queue_, main_task_queue_, completed_threads_));
+		auto add_task_result = task_queue_->AddTask(std::make_unique<OverlappedIOFileReadTask>(overlapped_io_file_read_, *new_read_offset, buffer_interval_in_bytes_, new_context_index, thread_count_, queue_depth_, task_queue_, main_task_queue_, completed_threads_));
 		switch (add_task_result) {
 		case max::Hardware::CPU::TaskQueue::AddTaskError::Okay:
 			break;
@@ -75,30 +68,6 @@ namespace FileReadSpeedTest {
 		case max::Hardware::CPU::TaskQueue::AddTaskError::CouldNotSetEvent:
 			return;
 		}
-
-
-
-
-
-
-		// After the previous read has completed, issue the next read.
-		/*
-		result = ReadFile(overlapped_io_file_read_->overlapped_io_file_.handle_, overlapped_io_file_read_->contexts_[new_context_index].buffer_.memory_, overlapped_io_file_read_->contexts_[new_context_index].bytes_to_read_, nullptr, &overlapped_io_file_read_->contexts_[new_context_index].overlapped_);
-		if (!result) {
-			DWORD error = GetLastError();
-			// TODO: ERROR_INVALID_USER_BUFFER or ERROR_NOT_ENOUGH_MEMORY if too many outstanding asynchronous IO operations
-			if (error != ERROR_IO_PENDING) {
-				// TODO: error
-				return;
-			}
-		}
-		*/
-
-		// TODO: Handle when the OS makes the operation synchronous:
-		// https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/asynchronous-disk-io-synchronous
-		// This can happen when FS compression or encryption is enabled.
-
-
 	}
 
 	Finished::Finished(size_t* completed_threads, size_t thread_count, max::Hardware::CPU::TaskQueue* main_task_queue) noexcept

--- a/Code/OverlappedIOFileReadTask.hpp
+++ b/Code/OverlappedIOFileReadTask.hpp
@@ -27,9 +27,7 @@ namespace FileReadSpeedTest {
 	class OverlappedIOFileReadTask : public max::Hardware::CPU::Task {
 	public:
 
-		//explicit OverlappedIOFileReadTask(HANDLE completion_port, size_t buffer_interval_in_bytes, LARGE_INTEGER file_size) noexcept;
-		//explicit OverlappedIOFileReadTask(OverlappedIOFileRead* overlapped_io_file_read) noexcept;
-		explicit OverlappedIOFileReadTask(OverlappedIOFileRead* overlapped_io_file_read, LARGE_INTEGER current_read_start, size_t buffer_interval_in_bytes, size_t context_index, size_t thread_count, max::Hardware::CPU::TaskQueue* task_queue, max::Hardware::CPU::TaskQueue* max_task_queue, size_t* completed_threads) noexcept;
+		explicit OverlappedIOFileReadTask(OverlappedIOFileRead* overlapped_io_file_read, LARGE_INTEGER current_read_start, size_t buffer_interval_in_bytes, size_t context_index, size_t thread_count, size_t queue_depth, max::Hardware::CPU::TaskQueue* task_queue, max::Hardware::CPU::TaskQueue* max_task_queue, size_t* completed_threads) noexcept;
 
 		void Run() noexcept override;
 
@@ -40,6 +38,7 @@ namespace FileReadSpeedTest {
 		LARGE_INTEGER current_read_start_;
 		size_t context_index_;
 		size_t thread_count_;
+		size_t queue_depth_;
 		max::Hardware::CPU::TaskQueue* task_queue_;
 		max::Hardware::CPU::TaskQueue* main_task_queue_;
 		size_t* completed_threads_;


### PR DESCRIPTION
This commit adds a --queue_depth command line parameter. It allows having a certain number of reads in flight. Different drives might respond differently to various queue depths.

This closes #13